### PR TITLE
oh-my-posh to v3

### DIFF
--- a/oh-my-posh/oh-my-posh.nuspec
+++ b/oh-my-posh/oh-my-posh.nuspec
@@ -58,7 +58,7 @@ This package appends the following lines to your Powershell Profile on Install i
 
 On uninstall, this package removes the following lines from your Powershell profile
  * 'Import-Module oh-my-posh' - Enables oh-my-posh
- * 'Set-Theme someTheme' - Any Themes set are removed from the profile.
+ * 'Set-PoshPrompt someTheme' - Any Themes set are removed from the profile.
  
 Posh-Git is not disabled on uninstall.
 

--- a/oh-my-posh/tools/chocolateyinstall.ps1
+++ b/oh-my-posh/tools/chocolateyinstall.ps1
@@ -57,10 +57,10 @@ if ($PROFILE -and (Test-Path $PROFILE)) {
   }
 
   Set-Content -path $profile -value $newProfile -Force
-  Write-Host "oh-my-posh has been added to your profile. You may wish to append 'Set-Theme paradox' to set a theme"
+  Write-Host "oh-my-posh has been added to your profile. You may wish to append 'Set-PoshPrompt paradox' to set a theme"
 }
 else{
-  Write-Host "No Powershell Profile was found. You may wish to create a Profile and append 'Import-Module posh-git', 'Import-Module oh-my-posh', and 'Set-Theme paradox' to enable oh-my-posh"
+  Write-Host "No Powershell Profile was found. You may wish to create a Profile and append 'Import-Module posh-git', 'Import-Module oh-my-posh', and 'Set-PoshPrompt paradox' to enable oh-my-posh"
 }
 
 Write-Host "You may need to change your Powershell Execution Policy to use $env:ChocolateyPackageName."

--- a/oh-my-posh/tools/chocolateyuninstall.ps1
+++ b/oh-my-posh/tools/chocolateyuninstall.ps1
@@ -21,7 +21,7 @@ if ($PROFILE -and (Test-Path $PROFILE)) {
         if($line -like 'Import-Module oh-my-posh') {
             continue
         }
-        if($line -like 'Set-Theme*') {
+        if($line -like 'Set-PoshPrompt*') {
             Write-Host "'$line' was setting a theme for your profile but is being removed."
             continue
         }

--- a/oh-my-posh/update.ps1
+++ b/oh-my-posh/update.ps1
@@ -9,9 +9,9 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $regex   = '\/JanDeDobbeleer\/oh-my-posh\/releases\/tag\/\d{1,3}\.\d{1,3}\.\d{1,3}$'
+  $regex   = '\/JanDeDobbeleer\/oh-my-posh\/releases\/tag\/v\d{1,3}\.\d{1,3}\.\d{1,3}$'
   $url     = $download_page.links | Where-Object href -match $regex | Select-Object -First 1 -expand href
-  $version = $url -split '\/' | Select-Object -Last 1
+  $version = $url -split '\/v' | Select-Object -Last 1
   Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
   Save-Module -RequiredVersion $version -Name 'oh-my-posh' -Force -Path './'
   Write-Host "Saved Module"


### PR DESCRIPTION
## Changes
1. Allow use of v3 of oh-my-posh, by picking up new release tags format.
2. Change v2 reference to `Set-Theme` to v3's `Set-PoshPrompt`.


FYI @JanDeDobbeleer, in case you spot anything else in the `chocolateyinstall.ps1` that may need changing.
@digitalcoyote I imagine the `oh-my-posh.nuspec` could use changing, but might leave that with you.

### Background
Seems like v3 was in a pre-release/beta state until recently, 
I'm a complete novice with chocolatey/powershell, but noticed that `oh-my-posh` has a new major version and was wondering why it wasn't getting picked up, looks to be that the version tags are prefixed with `v` now.


I was able to get the below terminal output, but couldn't figure out how to run `chocolateyinstall.ps1` after it unpacked the nupkg, so couldn't test it beyond that.
<details>
<summary>My amateur attempt at running update.ps1</summary>
<p>

```powershell
❯ .\update.ps1
oh-my-posh - checking updates using au version 2020.11.21
Install-PackageProvider: C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\update.ps1:15
Line |
  15 |    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Forc …
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Administrator rights are required to install packages in ''. Log
     | on to the computer with an account that has Administrator rights,
     | and then try again, or install in
     | 'C:\Users\adehad\AppData\Local\PackageManagement\ProviderAssemblies' by adding "-Scope CurrentUser" to your command. You can also try running the Windows PowerShell session with elevated rights (Run as Administrator).

Saved Module
Remove-Item: C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\update.ps1:25
Line |
  25 |    Remove-Item -Path "./oh-my-posh/$version/Build" -Force -Recurse
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path
     | 'C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh\3.106.4\Build' because it does not exist.

Remove-Item: C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\update.ps1:26
Line |
  26 |    Remove-Item -Path "./oh-my-posh/$version/.vscode" -Force -Recurse
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path
     | 'C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh\3.106.4\.vscode' because it does not exist.

Remove-Item: C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\update.ps1:27
Line |
  27 |    Remove-Item -Path "./oh-my-posh/$version/TestsResults.xml" -Force
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path
     | 'C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh\3.106.4\TestsResults.xml' because it does not exist.


URL check
nuspec version: 2.0.496
remote version: 3.106.4
New version is available
Automatic checksum skipped
Updating files
  $Latest data:
    NuspecVersion             (String)     2.0.496
    PackageName               (String)     oh-my-posh
    Version                   (String)     3.106.4
  oh-my-posh.nuspec
    setting id: oh-my-posh
    updating version: 2.0.496 -> 3.106.4
Attempting to build package from 'oh-my-posh.nuspec'.
Successfully created package 'C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh.3.106.4.nupkg'

Package updated

Path          : C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh
Name          : oh-my-posh
Updated       : True
Pushed        : False
RemoteVersion : 3.106.4
NuspecVersion : 2.0.496
Result        : {oh-my-posh - checking updates using au version 2020.11.21, , URL
                check, nuspec version: 2.0.496…}
Error         :                                                                                                          
NuspecPath    : C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh.nuspec                                                                                          NuspecXml     : #document
Ignored       : False                                                                                                    
IgnoreMessage :
StreamsPath   : C:\Users\adehad\Documents\GitHub\chocolatey-packages\oh-my-posh\oh-my-posh.json
Streams       :

```

</p>
</details>  


