### PR TITLE
Install deno with PATH instead shim

### DIFF
--- a/deno/tools/chocolateyinstall.ps1
+++ b/deno/tools/chocolateyinstall.ps1
@@ -15,4 +15,7 @@ foreach ($file in $files) {
 }
 Install-ChocolateyPath -PathToInstall $UnzipLocation
 
+# Remove shims installed with the old package
+Uninstall-BinFile deno "$UnzipLocation\deno.exe"
+
 Write-Output "Run 'deno --help' to get started"


### PR DESCRIPTION
> Signal handling is not working properly.
> 
> From Deno v1.23.0, [SIGINT and SIGBREAK](https://deno.land/manual@v1.27.0/examples/os_signals) are supported in Windows.
> 
> However, it does not work properly when started via the wrapper binary `%ChocolateyInstall%\bin\deno.exe`.

This is a chocolatey shimgen problem, not a deno one.

But this issue hasn't been resolved since 2016.
chocolatey/home#134

Therefore, change the installation method to add PATH instead of shim.
