### PR TITLE
oh-my-posh: Adding missing slashes in some ENV paths

### DIFF
--- a/oh-my-posh/tools/chocolateyinstall.ps1
+++ b/oh-my-posh/tools/chocolateyinstall.ps1
@@ -38,7 +38,7 @@ if (Test-Path $profile) {
 
     if ($pp['Theme']) {
         $themeName = $pp['Theme']
-        if (Test-Path "$env:LocalAppDataPrograms/oh-my-posh/themes/$($themeName).omp.json") {
+        if (Test-Path "$env:LocalAppData/Programs/oh-my-posh/themes/$($themeName).omp.json") {
             $ohMyPoshprofileLine = "Invoke-Expression (oh-my-posh --init --shell pwsh --config ""$env:LocalAppData/Programs/oh-my-posh/themes/$($themeName).omp.json"")"
             # $ohMyPoshprofileLine = "Set-PoshPrompt -Theme $themeName" # Suggestion for possible alternative
             if ($OhMyPoshInprofile) {
@@ -53,7 +53,7 @@ if (Test-Path $profile) {
             }
         }
         else {
-            Throw "Could not find Theme $themeName @ $env:LocalAppDataPrograms/oh-my-posh/themes/$($themeName).omp.json";
+            Throw "Could not find Theme $themeName @ $env:LocalAppData/Programs/oh-my-posh/themes/$($themeName).omp.json";
         }
         if (-Not($OhMyPoshInprofile)) {
             Add-Content -Path $profile -Value "Invoke-Expression (oh-my-posh --init --shell pwsh --config ""$env:LocalAppData/Programs/oh-my-posh/themes/$($themeName).omp.json"")";


### PR DESCRIPTION
Some of the uses of `$env:LocalAppData/Programs` were missing slashes between `Data` and `Programs`. As far as I can tell, there is no such thing as `$env:LocalAppDataPrograms`, so I assumed this is a typo!