### PR TITLE
Fix for Buildozer new version format

### DIFF
--- a/buildozer/update.ps1
+++ b/buildozer/update.ps1
@@ -16,9 +16,9 @@ function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
   $regex = '/bazelbuild/buildtools/releases/tag/v?[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}.*'
   $url = $download_page.links | Where-Object href -match $regex | Select-Object -First 1 -expand href
-  $version = $url -split '\/v|\/' | Select-Object -Last 1
+  $version = $url -split '\/' | Select-Object -Last 1
   $url = "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe"
-  return @{ Version = $version; URL64 = $url; ChecksumType64 = 'sha512';}
+  return @{ Version = $version -replace '^v'; URL64 = $url; ChecksumType64 = 'sha512';}
 }
 
 Update-Package -ChecksumFor 64

--- a/buildozer/update.ps1
+++ b/buildozer/update.ps1
@@ -14,9 +14,9 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $regex   = '/bazelbuild/buildtools/releases/tag/[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}.*'
+  $regex = '/bazelbuild/buildtools/releases/tag/v?[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}.*'
   $url = $download_page.links | Where-Object href -match $regex | Select-Object -First 1 -expand href
-  $version = $url -split '\/' | Select-Object -Last 1
+  $version = $url -split '\/v|\/' | Select-Object -Last 1
   $url = "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe"
   return @{ Version = $version; URL64 = $url; ChecksumType64 = 'sha512';}
 }


### PR DESCRIPTION
Basically similar fix as https://github.com/digitalcoyote/chocolatey-packages/pull/51 but for Buildozer: handle the added "v" in front of newer versions that has prevented the package to get updated with versions after 6.1.1.

This fix allows only the leading lowercase "v" (no other letters). I don't see a need to allow for any letter. Or is the letter range preferred? Feel free to update in that case.
(I don't understand how the uppercase range [A-Z] in the Buildifier fix matches the lowercase "v" in the URL, I don't see that case is ignored anywhere, but obviously it works as well, but it looks a bit weird when you know it's actually a lowercase "v")
